### PR TITLE
Fix Unpack UI freezes on some zero filled files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pywinstyles
 tarsafe
 asn1crypto
 lxml
+magic


### PR DESCRIPTION
According to liblp source code, the first 4096 bytes are always reserved, if lpunpack is unable to find the header magic at after the first 4096 bytes, it will always fail, so is_super() function isn't really useful, it's enough to just have the original is_super2(). (plus now it's causing freezes on large zero filled files, thus removing)

somehow, a fully zero filled file could semantically be a valid TAR archive 🤯
the tarfile.is_tarfile() implementation is too slow, i switched it to use libmagic, seems fine