### PR TITLE
chore(nix): add FHS shell to support tkinter and binaries on NixOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ pip install -r requirements.txt
 sudo apt update -y && sudo apt install python3-tk -y
 ````
 
+If using NixOS
+
+```` shell
+nix-shell
+````
+
 </details>
 
 <details><summary>Windows</summary>

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,64 @@
+{ pkgs ? import (fetchTarball "https://github.com/nixos/nixpkgs/archive/nixos-unstable.tar.gz") {
+    config.allowUnfree = true;
+  }
+}:
+
+let
+  pythonWithTk = pkgs.python313.withPackages (ps: with ps; [
+    pip
+    tkinter
+    requests
+    exceptiongroup
+    python-lzo
+  ]);
+
+  fhsEnv = pkgs.buildFHSEnv {
+    name = "mio-kitchen-fhs";
+
+    targetPkgs = pkgs: (with pkgs; [
+      pythonWithTk
+      tcl
+      tk
+      libxcb
+      xcb-proto
+      libxcursor
+      xorg.libX11
+      zlib
+      stdenv.cc.cc.lib
+    ]);
+
+    runScript = pkgs.writeScript "init-fhs.sh" ''
+      # Manually configure tkinter on NixOS
+      # Refs: https://github.com/NixOS/nixpkgs/issues/238990#issuecomment-2840390721
+      export PYTHONPATH="${pythonWithTk}/lib/python3.13/site-packages:$PYTHONPATH"
+      export TCL_LIBRARY="${pkgs.tcl}/lib/tcl${pkgs.tcl.version}"
+      export TK_LIBRARY="${pkgs.tk}/lib/tk${pkgs.tk.version}"
+
+      # Install under venv
+      export VENV_DIR="$PWD/.venv"
+      if [ ! -d "$VENV_DIR" ]; then
+        python -m venv $VENV_DIR
+      fi
+      source $VENV_DIR/bin/activate
+
+      # Install deps
+      pip install -r requirements.txt
+
+      PYTHON_VERSION=$(python --version)
+      echo ""
+      echo -e "\033[1;35m[FHS Container]\033[0m Welcome! Running: (\033[1;34m$PYTHON_VERSION\033[0m)"
+
+      export PS1="\n\[\033[1;35m\](FHS:mio-kitchen) \[\033[1;32m\]\u@\h\[\033[00m\]:\[\033[1;34m\]\w\[\033[00m\]\n\$ "
+
+      exec bash --norc
+    '';
+  };
+in
+pkgs.stdenv.mkDerivation {
+  name = "fhs-shell";
+  nativeBuildInputs = [ fhsEnv ];
+
+  shellHook = ''
+    exec ${fhsEnv}/bin/mio-kitchen-fhs
+  '';
+}


### PR DESCRIPTION
NixOS uses a non-FHS hierarchy, which means its libraries and packages are not located in standard FHS paths (/usr/lib, etc). This causes three major issues:
   1. python-tkinter can't find TCL/TK libraries automatically.
   2. Fails to import the _tkinter module in venv on NixOS.
   3. Prebuilt binaries in this project fail to execute due to the missing loader and libraries.

Therefore a `shell.nix` is necessary to utilize `buildFHSEnv` to create a fake chroot environment that mimics a standard FHS environment and provides a series of environment variables to enable tkinter on NixOS correctly.

Refs: https://github.com/NixOS/nixpkgs/issues/238990#issuecomment-2840390721