### PR TITLE
fix(f2fs): align f2fs image size to 4k boundaries

### DIFF
--- a/src/tkui/tool.py
+++ b/src/tkui/tool.py
@@ -6774,8 +6774,20 @@ def make_f2fs(name: str, work: str, work_output: str, UTC: int = None):
     print(lang.text91 % name)
     size = GetFolderSize(work + name, 1, 1).rsize_v
     print(f"{name}:[{size}]")
-    size_f2fs = (54 * 1024 * 1024) + size
-    size_f2fs = int(size_f2fs * 1.15) + 1
+
+    def align_to_4k(size):
+        # Align the size upwards to multiples of 4096 bytes.
+        return (size + 4095) // 4096 * 4096
+
+    # Set to 64MB to reserve space for F2FS Metadata
+    size_f2fs = (64 * 1024 * 1024) + size
+    # Apply a safety margin
+    size_f2fs = int(size_f2fs * 1.15)
+    # Align size to 4096-byte multiples.
+    # Android dynamic partitions require sector alignment. 
+    # Mismatched block sizes will cause 'lpmake' read errors or mount failures.
+    size_f2fs = align_to_4k(size_f2fs)
+
     if not UTC:
         UTC = int(time.time())
     with open(f"{work + name}.img", 'wb') as f:


### PR DESCRIPTION
The primary issue was the lack of 4K sector alignment in the calculated image size. This misalignment causes `lpmake` to fail when packing Android dynamic super partitions, resulting in build failures. 

By introducing a helper function to align the final size upwards to 4096-byte multiples, it has been ensured that our behavior is compatible with AOSP's requirements.

Also increase the reserved metadata size from 54MB to 64MB as a safety margin, although 54MB was technically sufficient.

The 15% safety margin calculation remains unchanged.

Additionally, caution should still be exercised when using imgkit at this stage, as it still has issues with f2fs unpacking. Check https://github.com/Kindness-Kismet/ImgKit-Scuti/issues/1#issuecomment-3985465709 for details